### PR TITLE
feat: Add dark mode toggle

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { Button } from './Button';
+
+export function ThemeToggle() {
+  const [isDark, setIsDark] = useState(true);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('theme');
+    if (saved) setIsDark(saved === 'dark');
+  }, []);
+
+  const toggle = () => {
+    const newTheme = !isDark;
+    setIsDark(newTheme);
+    localStorage.setItem('theme', newTheme ? 'dark' : 'light');
+    document.documentElement.classList.toggle('dark', newTheme);
+  };
+
+  return (
+    <Button variant='ghost' onClick={toggle} aria-label='Toggle theme'>
+      {isDark ? <Sun className='w-5 h-5' /> : <Moon className='w-5 h-5' />}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Description
Adds a theme toggle component that allows users to switch between dark and light themes.

## Changes
- New ThemeToggle component with Lucide icons
- Theme persistence via localStorage
- CSS class toggling for theme switching

## Screenshots
N/A - UI component

## Checklist
- [x] Component created
- [x] localStorage integration
- [x] Accessibility support